### PR TITLE
comment submit max 1000 fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.4.1)
       activesupport (= 5.2.4.1)
       arel (>= 9.0)
+    activerecord-import (1.0.4)
+      activerecord (>= 3.2)
     activestorage (5.2.4.1)
       actionpack (= 5.2.4.1)
       activerecord (= 5.2.4.1)
@@ -207,6 +209,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/board_comments_controller.rb
+++ b/app/controllers/board_comments_controller.rb
@@ -8,14 +8,32 @@ class BoardCommentsController < ApplicationController
   end
 
   def create
-     @comment = Boardcomment.new(params[:form_comment])
-     @comment.board_id = params[:id]
-     @comment.commentator = session[:name]
+    @comment = Boardcomment.new(params[:form_comment])
+    @comment.board_id = params[:id]
+    @comment.commentator = session[:name]
 
-     if @comment.save
-        redirect_to board_comment_url, notice: "コメントを送信しました。"
-     else
-       render "board_comment"
-     end
+    @comments_count = Boardcomment.where(board_id: params[:id] ).count
+    
+
+    # 登録済みコメントが1000コメント以上の場合
+    begin
+      if @comments_count >= 1000
+        raise "コメントが1000コメントを超えました"
+      end
+    rescue  Exception
+      flash.alert = "コメントが1000コメントを超えました。新しい掲示板を作成してください。
+      "
+      redirect_to board_comment_url
+      return
+    end
+    
+    # 登録済みコメントが1000コメント未満の場合
+    if @comment.save
+      redirect_to board_comment_url, notice: "コメントを送信しました。"
+      return
+    else
+      render "board_comment"
+      return
+    end
   end
 end

--- a/app/views/board_comments/index.html.erb
+++ b/app/views/board_comments/index.html.erb
@@ -18,6 +18,13 @@
         </div>
       <% end %>
     </div>
+    <div class="alert-area">
+      <% if flash.alert %>
+        <p class="alert">
+          <%= flash.alert %>
+        </p>
+      <% end %>
+    </div>
     <div class="main-comment-box">
       <div class="board_name">
         <h2>掲示板名：<%= @board.board_name %></h2>

--- a/spec/system/board_comments_spec.rb
+++ b/spec/system/board_comments_spec.rb
@@ -30,4 +30,29 @@ describe '掲示板コメント投稿機能', type: :system do
       end
     end
   end
+
+  describe 'コメント投稿機能' do
+    before do
+      user_a = FactoryBot.create(:user, name: 'user_a')
+      board = FactoryBot.create(:board, board_name: 'test_board', genre: 'マンガ', creator_name: 'user_A')
+      comments = FactoryBot.build_list(:boardcomment, 1000, board_id: board.id, comment: 'おはよう', commentator: 'user_A')
+      Boardcomment.import comments
+    end
+    context 'コメントが1000コメントある状態のとき' do
+      before do
+        visit login_path
+        fill_in 'name', with: 'user_a'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+        click_link 'test_board'
+      end
+
+      it '1000コメントある状態でコメントを送信したとき、alertメッセージが表示される' do
+         fill_in 'form_comment_comment', with: 'こんばんは'
+         click_button 'コメント送信'
+
+         expect(page).to have_content 'コメントが1000コメントを超えました。新しい掲示板を作成してください。'
+      end
+    end
+  end
 end


### PR DESCRIPTION
1掲示板あたりの1000コメント制限の処理を以下のファイルに修正
- board_comments_controller.rb
- board_comments/index.html.erb
- board_comments_spec.rb

テストデータの大量登録するために以下のgemを追加
- activerecord-import